### PR TITLE
Fix power check before enabling devices

### DIFF
--- a/IoTDevice.h
+++ b/IoTDevice.h
@@ -40,6 +40,13 @@ public:
     int getBasePower() const{
         return base_power;
     }
+    int calculatePowerConsumption() const{
+        double temp = getCurrentTemperature();
+        return static_cast<int>(base_power * (1.0 + std::abs(temp - 20.0) * 0.012));
+    }
+    void refreshPowerConsumption(){
+        power_consumption = calculatePowerConsumption();
+    }
     int getPriority() const{
         return priority;
     }
@@ -52,8 +59,7 @@ public:
     }
     void consumeEnergy() {
         if (is_on) {
-            double temp = getCurrentTemperature();
-            power_consumption = static_cast<int>(base_power * (1.0 + std::abs(temp - 20.0) * 0.012));
+            refreshPowerConsumption();
             energy_consumed += power_consumption;
         }
     }

--- a/Power_Grid.cpp
+++ b/Power_Grid.cpp
@@ -78,17 +78,21 @@ void PowerGrid::checkLimits(const std::vector<std::shared_ptr<IoTDevice>>& devic
             });
 
         for (auto& dev : offDevices) {
-            // Оценка потребления через base_power с учётом температуры
-            double temp = IoTDevice::getCurrentTemperature();
-            int estimatedPower = static_cast<int>(dev->getBasePower() * (1.0 + std::abs(temp - 20.0) * 0.012));
+            dev->turnOn();
+            dev->refreshPowerConsumption();
+            int currentPower = dev->getPowerConsumption();
 
-            if (total + estimatedPower <= limit) {
-                dev->turnOn();
-                total += estimatedPower;
+            if (total + currentPower <= limit) {
+                total += currentPower;
                 Logger::info("[Сеть] Включён " + dev->getName() +
-                             " (потребление: ~" + std::to_string(estimatedPower) + " Вт" +
+                             " (потребление: " + std::to_string(currentPower) + " Вт" +
                              ", приоритет: " + std::to_string(dev->getPriority()) + ")" +
                              ", резерв: " + std::to_string(limit - total) + " Вт");
+            } else {
+                dev->turnOff();
+                Logger::warn("[Сеть] Недостаточно резерва для включения " + dev->getName() +
+                             " (нужно: " + std::to_string(currentPower) + " Вт" +
+                             ", резерв: " + std::to_string(limit - total) + " Вт)");
             }
         }
     }


### PR DESCRIPTION
Fixes #40.
close/#40

Changes:
- Recalculates actual device power before enabling it.
- Keeps the device off when reserve is not enough.
- Reuses the same power calculation in energy consumption.