### PR TITLE
Apply global temperature power multiplier

### DIFF
--- a/IoTDevice.h
+++ b/IoTDevice.h
@@ -40,6 +40,9 @@ public:
     int getBasePower() const{
         return base_power;
     }
+    int calculatePowerConsumption() const{
+        return static_cast<int>(base_power * getTemperaturePowerMultiplier());
+    }
     int getPriority() const{
         return priority;
     }
@@ -50,10 +53,13 @@ public:
         static double temp = 20.0;
         return temp;
     }
+    static double getTemperaturePowerMultiplier() {
+        double temp = getCurrentTemperature();
+        return (temp < -5.0 || temp > 35.0) ? 1.2 : 1.0;
+    }
     void consumeEnergy() {
         if (is_on) {
-            double temp = getCurrentTemperature();
-            power_consumption = static_cast<int>(base_power * (1.0 + std::abs(temp - 20.0) * 0.012));
+            power_consumption = calculatePowerConsumption();
             energy_consumed += power_consumption;
         }
     }

--- a/Power_Grid.cpp
+++ b/Power_Grid.cpp
@@ -79,8 +79,7 @@ void PowerGrid::checkLimits(const std::vector<std::shared_ptr<IoTDevice>>& devic
 
         for (auto& dev : offDevices) {
             // Оценка потребления через base_power с учётом температуры
-            double temp = IoTDevice::getCurrentTemperature();
-            int estimatedPower = static_cast<int>(dev->getBasePower() * (1.0 + std::abs(temp - 20.0) * 0.012));
+            int estimatedPower = dev->calculatePowerConsumption();
 
             if (total + estimatedPower <= limit) {
                 dev->turnOn();
@@ -96,8 +95,9 @@ void PowerGrid::checkLimits(const std::vector<std::shared_ptr<IoTDevice>>& devic
     // --- РЕЗЕРВ ---
     int reserve = limit - total;
     int reservePercent = (limit > 0) ? (reserve * 100 / limit) : 0;
-    int lightPower = 20;
-    int sensorPower = 15;
+    double powerMultiplier = IoTDevice::getTemperaturePowerMultiplier();
+    int lightPower = static_cast<int>(20 * powerMultiplier);
+    int sensorPower = static_cast<int>(15 * powerMultiplier);
     int possibleLights = (reserve > 0) ? reserve / lightPower : 0;
     int possibleSensors = (reserve > 0) ? reserve / sensorPower : 0;
 

--- a/main.cpp
+++ b/main.cpp
@@ -21,7 +21,6 @@ using namespace std;
 int main() {
     const int NUM_SENSORS = 20;
     const int NUM_LIGHTS = 10;
-    const int NUM_TEMP_SENSORS = 5;
     const int SIM_STEPS = 20;
     const int STEP_DELAY_MS = 500;
 
@@ -32,6 +31,10 @@ int main() {
     PowerGrid grid;
 
     vector<shared_ptr<IoTDevice>> allDevices;
+
+    auto tempSensor = make_shared<TemperatureSensor>("ТемпДатчик-1");
+    hub.addDevice(tempSensor);
+    allDevices.push_back(tempSensor);
 
     for (int i = 1; i <= NUM_SENSORS; i++) {
         auto sensor = make_shared<AirSensor>("Датчик-" + to_string(i));
@@ -54,12 +57,6 @@ int main() {
         auto light = make_shared<TrafficLight>("Светофор-" + to_string(i + 1), 20, schedule);
         hub.addDevice(light);
         allDevices.push_back(light);
-    }
-
-    for (int i = 1; i <= NUM_TEMP_SENSORS; i++) {
-        auto tempSensor = make_shared<TemperatureSensor>("ТемпДатчик-" + to_string(i));
-        hub.addDevice(tempSensor);
-        allDevices.push_back(tempSensor);
     }
 
     Logger::info("Запуск симуляции умного города");


### PR DESCRIPTION
Fixes #41.

Changes:
- Leaves one temperature sensor in the simulation.
- Updates temperature before other devices on each tick.
- Applies a 20% power increase to all devices when temperature is below -5C or above 35C.
- Uses the same multiplier for power-grid reserve estimates.